### PR TITLE
Change Docker image location to ghcr

### DIFF
--- a/mastodon-chart/values.yaml
+++ b/mastodon-chart/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: tootsuite/mastodon
+  repository: ghcr.io/mastodon/mastodon
   pullPolicy: IfNotPresent
   tag: "v4.1.0"
 


### PR DESCRIPTION
In response to https://toot.community/@vmstan@vmst.io/110027699914564836

Currently ghcr is down so I can't 100% verify the location at this moment. Will try again tonight.