### PR TITLE
Bumped all versions wherever available

### DIFF
--- a/argocd/applications/grafana.yaml
+++ b/argocd/applications/grafana.yaml
@@ -62,4 +62,4 @@ spec:
             role_attribute_path: contains(groups[*], '@toot-community/administrators') && 'GrafanaAdmin' || 'Viewer'
             allow_assign_grafana_admin: true
     repoURL: https://grafana.github.io/helm-charts
-    targetRevision: 6.52.2
+    targetRevision: 6.52.4

--- a/argocd/applications/ingress-nginx.yaml
+++ b/argocd/applications/ingress-nginx.yaml
@@ -56,4 +56,4 @@ spec:
               service.beta.kubernetes.io/do-loadbalancer-protocol: "http2"
               service.beta.kubernetes.io/do-loadbalancer-tls-passthrough: "true"
     repoURL: https://kubernetes.github.io/ingress-nginx
-    targetRevision: 4.4.2
+    targetRevision: 4.5.2

--- a/argocd/applications/keda.yaml
+++ b/argocd/applications/keda.yaml
@@ -15,7 +15,7 @@ spec:
   source:
     chart: keda
     repoURL: https://kedacore.github.io/charts
-    targetRevision: 2.10.0
+    targetRevision: 2.10.1
     helm:
       values: |
         operator:

--- a/argocd/applications/kube-state-metrics.yaml
+++ b/argocd/applications/kube-state-metrics.yaml
@@ -14,4 +14,4 @@ spec:
   source:
     chart: kube-state-metrics
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 4.29.0
+    targetRevision: 5.0.0

--- a/argocd/applications/prometheus.yaml
+++ b/argocd/applications/prometheus.yaml
@@ -68,4 +68,4 @@ spec:
         prometheus-node-exporter:
           enabled: true
     repoURL: https://prometheus-community.github.io/helm-charts
-    targetRevision: 19.3.3
+    targetRevision: 19.7.2


### PR DESCRIPTION
Searched the internet for newer versions of all components. Found a few; only kube-state-metrics is a major version upgrade. All others are minor bumps.